### PR TITLE
Feature/performance optimizations

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,13 @@ To allow the images to change on resize, add this include to your head in the la
 @include('statamic-glide-directive::partials.head')
 ```
 
+We recommend to generate your presets by using `php please assets:generate-presets`.
+
+To combat performance issues we recommend using redis for your queue connection, if you keep this on sync the images will be generated on the fly impacting page load.
+
+When using redis the images will also be made on the fly, while working the jobs on the queue. If an image doesn't have a glide preset ready we will use the original image url for the first page load.
+
+
 ## Config
 
 The package has some default config. By default it will use the presets defined in the config of this addon. If you've defined you're asset presets in the Statamic config, that will be used.

--- a/resources/views/image.blade.php
+++ b/resources/views/image.blade.php
@@ -11,29 +11,29 @@
         @else
             @isset($presets['webp'])
                 <source
-                        srcset="{{ $presets['webp'] }}"
-                        sizes="32px"
-                        type="image/webp"
+                    srcset="{{ $presets['webp'] }}"
+                    sizes="32px"
+                    type="image/webp"
                 >
             @endisset
             @isset($presets[$image->mimeType()])
                 <source
-                        srcset="{{ $presets[$image->mimeType()] }}"
-                        sizes="32px"
-                        type="{{ $image->mimeType() }}"
+                    srcset="{{ $presets[$image->mimeType()] }}"
+                    sizes="32px"
+                    type="{{ $image->mimeType() }}"
                 >
             @endisset
             <img
-                {!! $attributes ?? '' !!}
-                class="{{ $class }}"
-                src="{{ isset($presets['webp']) || isset($presets[$image->mimeType()]) ? ($presets['placeholder'] ?? $image->url()) : $image->url() }}"
-                alt="{{ $alt ?? $image->alt() }}"
-                width="{{ $width }}"
-                height="{{ $height }}"
-                onload="
-                    this.onload=null;
-                    window.responsiveResizeObserver.observe(this);
-                "
+                    {!! $attributes ?? '' !!}
+                    class="{{ $class }}"
+                    src="{{ $presets['placeholder'] ?? $image->url() }}"
+                    alt="{{ $alt ?? $image->alt() }}"
+                    width="{{ $width }}"
+                    height="{{ $height }}"
+                    onload="
+                        this.onload=null;
+                        window.responsiveResizeObserver.observe(this);
+                    "
             >
         @endif
     </picture>

--- a/resources/views/image.blade.php
+++ b/resources/views/image.blade.php
@@ -26,7 +26,7 @@
             <img
                 {!! $attributes ?? '' !!}
                 class="{{ $class }}"
-                src="{{ $presets['placeholder'] ?? $image->url() }}"
+                src="{{ isset($presets['webp']) || isset($presets[$image->mimeType()]) ? ($presets['placeholder'] ?? $image->url()) : $image->url() }}"
                 alt="{{ $alt ?? $image->alt() }}"
                 width="{{ $width }}"
                 height="{{ $height }}"

--- a/src/Jobs/GenerateGlideImageJob.php
+++ b/src/Jobs/GenerateGlideImageJob.php
@@ -3,16 +3,14 @@
 namespace JustBetter\GlideDirective\Jobs;
 
 use Illuminate\Bus\Queueable;
-use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
-use JustBetter\ImageOptimize\Contracts\ResizesImage;
 use Statamic\Assets\Asset;
 use Illuminate\Bus\Batchable;
 use Statamic\Statamic;
 
-class GenerateGlideImageJob implements ShouldQueue, ShouldBeUnique
+class GenerateGlideImageJob implements ShouldQueue
 {
     use Dispatchable;
     use InteractsWithQueue;
@@ -29,11 +27,15 @@ class GenerateGlideImageJob implements ShouldQueue, ShouldBeUnique
 
     public function handle(): void
     {
-        Statamic::tag($this->preset === 'placeholder' ? 'glide:data_url' : 'glide')->params(['preset' => $this->preset, 'src' => $this->asset->url(), 'format' => $this->format, 'fit' => $this->fit])->fetch();
-    }
-
-    public function uniqueId(): string
-    {
-        return $this->asset->id();
+        Statamic::tag(
+            $this->preset === 'placeholder' ? 'glide:data_url' : 'glide'
+        )->params(
+            [
+                'preset' => $this->preset,
+                'src' => $this->asset->url(),
+                'format' => $this->format,
+                'fit' => $this->fit
+            ]
+        )->fetch();
     }
 }

--- a/src/Jobs/GenerateGlideImageJob.php
+++ b/src/Jobs/GenerateGlideImageJob.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace JustBetter\GlideDirective\Jobs;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldBeUnique;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use JustBetter\ImageOptimize\Contracts\ResizesImage;
+use Statamic\Assets\Asset;
+use Illuminate\Bus\Batchable;
+use Statamic\Statamic;
+
+class GenerateGlideImageJob implements ShouldQueue, ShouldBeUnique
+{
+    use Dispatchable;
+    use InteractsWithQueue;
+    use Queueable;
+    use Batchable;
+
+    public function __construct(
+        public Asset $asset,
+        public string $preset = '',
+        public string $fit = '',
+        public ?string $format = null,
+    ) {
+    }
+
+    public function handle(): void
+    {
+        Statamic::tag($this->preset === 'placeholder' ? 'glide:data_url' : 'glide')->params(['preset' => $this->preset, 'src' => $this->asset->url(), 'format' => $this->format, 'fit' => $this->fit])->fetch();
+    }
+
+    public function uniqueId(): string
+    {
+        return $this->asset->id();
+    }
+}

--- a/src/Responsive.php
+++ b/src/Responsive.php
@@ -2,27 +2,20 @@
 
 namespace JustBetter\GlideDirective;
 
+use JustBetter\GlideDirective\Jobs\GenerateGlideImageJob;
+use Statamic\Imaging\GlideImageManipulator;
 use Illuminate\Contracts\View\Factory;
 use Illuminate\Contracts\View\View;
-use JustBetter\GlideDirective\Jobs\GenerateGlideImageJob;
-use Statamic\Assets\Asset;
-use Statamic\Contracts\Assets\Asset as AssetContract;
-use Statamic\Facades\Config;
 use Statamic\Facades\Glide;
 use Statamic\Facades\Image;
 use Statamic\Facades\URL;
+use Statamic\Assets\Asset;
 use Statamic\Fields\Value;
-use Statamic\Imaging\GlideImageManipulator;
-use Statamic\Imaging\ImageGenerator;
-use Statamic\Statamic;
 use Statamic\Support\Str;
+use Statamic\Statamic;
 
 class Responsive
 {
-    public function __construct(public GlideImageManipulator $glideImageManipulator)
-    {
-    }
-
     public static function handle(mixed ...$arguments): Factory|View|string
     {
         $asset = $arguments[0];

--- a/src/Responsive.php
+++ b/src/Responsive.php
@@ -126,9 +126,14 @@ class Responsive
         }
 
         $manipulator = self::getManipulator($asset, $preset, $fit, $format);
+
+        if (is_string($manipulator)) {
+            return null;
+        }
+
         $params = $manipulator->getParams();
 
-        $manipulationCacheKey = 'asset::' . $asset->id() . '::' . md5(json_encode($params) ?? '');
+        $manipulationCacheKey = 'asset::' . $asset->id() . '::' . md5(json_encode($params) ? json_encode($params) : '');
 
         if ($cachedUrl = Glide::cacheStore()->get($manipulationCacheKey)) {
             $url = Str::ensureLeft(config('statamic.assets.image_manipulation.route'), '/') . '/' . $cachedUrl;
@@ -140,7 +145,7 @@ class Responsive
         return null;
     }
 
-    protected static function getManipulator(Asset $item, string $preset, string $fit, ?string $format = null): ImageManipulator
+    protected static function getManipulator(Asset $item, string $preset, string $fit, ?string $format = null): ImageManipulator|string
     {
         $manipulator = Image::manipulate($item);
 

--- a/src/Responsive.php
+++ b/src/Responsive.php
@@ -3,7 +3,6 @@
 namespace JustBetter\GlideDirective;
 
 use JustBetter\GlideDirective\Jobs\GenerateGlideImageJob;
-use Statamic\Imaging\GlideImageManipulator;
 use Statamic\Contracts\Imaging\ImageManipulator;
 use Illuminate\Contracts\View\Factory;
 use Illuminate\Contracts\View\View;

--- a/src/Responsive.php
+++ b/src/Responsive.php
@@ -4,34 +4,47 @@ namespace JustBetter\GlideDirective;
 
 use Illuminate\Contracts\View\Factory;
 use Illuminate\Contracts\View\View;
+use JustBetter\GlideDirective\Jobs\GenerateGlideImageJob;
 use Statamic\Assets\Asset;
+use Statamic\Contracts\Assets\Asset as AssetContract;
+use Statamic\Facades\Config;
+use Statamic\Facades\Glide;
+use Statamic\Facades\Image;
+use Statamic\Facades\URL;
 use Statamic\Fields\Value;
+use Statamic\Imaging\GlideImageManipulator;
+use Statamic\Imaging\ImageGenerator;
 use Statamic\Statamic;
+use Statamic\Support\Str;
 
 class Responsive
 {
+    public function __construct(public GlideImageManipulator $glideImageManipulator)
+    {
+    }
+
     public static function handle(mixed ...$arguments): Factory|View|string
     {
-        $image = $arguments[0];
-        $image = $image instanceof Value ? $image->value() : $image;
+        $asset = $arguments[0];
+        $asset = $asset instanceof Value ? $asset->value() : $asset;
         $arguments = $arguments[1] ?? [];
 
-        if (! $image || ! ($image instanceof Asset)) {
+        if (! $asset || ! ($asset instanceof Asset)) {
             return '';
         }
 
         return view('statamic-glide-directive::image', [
-            'image' => $image,
-            'presets' => self::getPresets($image),
+            'image' => $asset,
+            'presets' => self::getPresets($asset),
             'attributes' => self::getAttributeBag($arguments),
             'class' => $arguments['class'] ?? '',
             'alt' => $arguments['alt'] ?? '',
-            'width' => $arguments['width'] ?? $image->width(),
-            'height' => $arguments['height'] ?? $image->height(),
+            'width' => $arguments['width'] ?? $asset->width(),
+            'height' => $arguments['height'] ?? $asset->height(),
         ]);
     }
 
-    public static function getPresets(Asset $image): array
+    public static function getPresets(Asset $asset): array
     {
         $config = config('statamic.assets.image_manipulation.presets');
 
@@ -46,13 +59,14 @@ class Responsive
         }
 
         if (self::canUseMimeTypeSource()) {
-            $presets[$image->mimeType()] = '';
+            $presets[$asset->mimeType()] = '';
         }
 
-        $configPresets = self::getPresetsByRatio($image, $config);
-        $imageMeta = $image->meta();
-        $fit = isset($imageMeta['data']['focus']) ? sprintf('crop-%s', $imageMeta['data']['focus']) : null;
+        $configPresets = self::getPresetsByRatio($asset, $config);
+        $assetMeta = $asset->meta();
+        $fit = isset($assetMeta['data']['focus']) ? sprintf('crop-%s', $assetMeta['data']['focus']) : null;
         $index = 0;
+
         foreach ($configPresets as $preset => $data) {
             $size = $data['w'].'w';
 
@@ -60,22 +74,16 @@ class Responsive
                 $size .= ', ';
             }
 
-            if (self::canUseWebpSource()) {
-                $glideUrl = Statamic::tag($preset === 'placeholder' ? 'glide:data_url' : 'glide')->params(['preset' => $preset, 'src' => $image->url(), 'format' => 'webp', 'fit' => $fit ?? $data['fit']])->fetch();
-                if ($glideUrl) {
-                    $presets['webp'] .= $glideUrl.' '.$size;
-                }
+            if (self::canUseWebpSource() && $glideUrl = self::getGlideUrl($asset, $preset, $fit ?? $data['fit'], 'webp')) {
+                $presets['webp'] .= $glideUrl.' '.$size;
             }
 
-            if (self::canUseMimeTypeSource()) {
-                $glideUrl = Statamic::tag($preset === 'placeholder' ? 'glide:data_url' : 'glide')->params(['preset' => $preset, 'src' => $image->url(), 'fit' => $fit ?? $data['fit']])->fetch();
-                if ($glideUrl) {
-                    $presets[$image->mimeType()] .= $glideUrl.' '.$size;
-                }
+            if (self::canUseMimeTypeSource() && $glideUrl = self::getGlideUrl($asset, $fit ?? $data['fit'], $preset)) {
+                $presets[$asset->mimeType()] .= $glideUrl.' '.$size;
             }
 
             if ($preset === 'placeholder') {
-                $glideUrl = Statamic::tag('glide:data_url')->params(['preset' => 'placeholder', 'src' => $image->url(), 'fit' => $fit ?? $data['fit']])->fetch();
+                $glideUrl = Statamic::tag('glide:data_url')->params(['preset' => 'placeholder', 'src' => $asset->url(), 'fit' => $fit ?? $data['fit']])->fetch();
                 if ($glideUrl) {
                     $presets['placeholder'] = $glideUrl;
                 }
@@ -85,19 +93,53 @@ class Responsive
         }
 
         if (! isset($presets['placeholder'])) {
-            $glideUrl = Statamic::tag('glide:data_url')->params(['preset' => collect($configPresets)->keys()->first(), 'src' => $image->url(), 'fit' => 'crop_focal'])->fetch();
+            $glideUrl = Statamic::tag('glide:data_url')->params(['preset' => collect($configPresets)->keys()->first(), 'src' => $asset->url(), 'fit' => 'crop_focal'])->fetch();
             $presets['placeholder'] = $glideUrl;
         }
 
         return $presets;
     }
 
-    protected static function getPresetsByRatio(Asset $image, array $config): array
+    protected static function getGlideUrl(Asset $asset, string $preset, string $fit, ?string $format = null): ?string
+    {
+        if ($preset === 'placeholder') {
+            return Statamic::tag('glide:data_url')->params(['preset' => $preset, 'src' => $asset->url(), 'format' => $format, 'fit' => $fit])->fetch();
+        }
+
+        $manipulator = self::getManipulator($asset, $preset, $fit, $format);
+        $params = $manipulator->getParams();
+
+        $manipulationCacheKey = 'asset::' . $asset->id() . '::' . md5(json_encode($params));
+
+        if (Glide::cacheStore()->has($manipulationCacheKey)) {
+            $cachedUrl = Glide::cacheStore()->get($manipulationCacheKey);
+            $url = Str::ensureLeft(config('statamic.assets.image_manipulation.route'), '/') . '/' . $cachedUrl;
+
+            return URL::encode($url);
+        }
+
+        GenerateGlideImageJob::dispatch($asset, $preset, $fit, $format);
+
+        return null;
+    }
+
+    protected static function getManipulator(Asset $item, string $preset, string $fit, ?string $format = null): GlideImageManipulator
+    {
+        $manipulator = Image::manipulate($item);
+
+        collect(['p' => $preset, 'fm' => $format, 'fit' => $fit])->each(function ($value, $param) use ($manipulator) {
+            $manipulator->$param($value);
+        });
+
+        return $manipulator;
+    }
+
+    protected static function getPresetsByRatio(Asset $asset, array $config): array
     {
         $presets = collect($config);
 
         // filter config based on aspect ratio
-        $vertical = $image->height() > $image->width();
+        $vertical = $asset->height() > $asset->width();
         $presets = $presets->filter(fn ($preset, $key) => $key === 'placeholder' || (($preset['h'] > $preset['w']) === $vertical));
 
         return $presets->isNotEmpty() ? $presets->toArray() : $config;


### PR DESCRIPTION
If there's a lot of images on one page there could be some serious performance issues if the glide presets aren't already generated through the `php please assets:generate-presets` command.

This PR changes some things around, first we check if the manipulated image exists in the cache store, if so we return it.
If it doesn't exist we generate the image using a job which we can put on a queue in the background, while just showing the original image url on the frontend.

The next time the page is loaded, and the job has finished generating the image, the image will make use of its presets.

