### PR TITLE
Prevent render blocking resizes

### DIFF
--- a/resources/views/image.blade.php
+++ b/resources/views/image.blade.php
@@ -26,12 +26,16 @@
             <img
                     {!! $attributes ?? '' !!}
                     class="{{ $class }}"
+                    style="background-image: url('{{ $presets['placeholder'] }}'); background-size: contain; background-position: center; background-repeat: no-repeat;"
                     src="{{ $presets['placeholder'] ?? $image->url() }}"
                     alt="{{ $alt ?? $image->alt() }}"
                     width="{{ $width }}"
                     height="{{ $height }}"
                     onload="
-                        this.onload=null;
+                        this.onload=()=>{
+                            this.style.backgroundImage = null;
+                            this.onload=null
+                        };
                         window.responsiveResizeObserver.observe(this);
                     "
             >

--- a/resources/views/image.blade.php
+++ b/resources/views/image.blade.php
@@ -28,7 +28,7 @@
                     class="{{ $class }}"
                     @if($presets['placeholder'] ?? false)
                         style="background-image: url('{{ $presets['placeholder'] }}'); background-size: contain; background-position: center; background-repeat: no-repeat;"
-                    @endif                    ]
+                    @endif
                     src="{{ $presets['placeholder'] ?? $image->url() }}"
                     alt="{{ $alt ?? $image->alt() }}"
                     width="{{ $width }}"

--- a/resources/views/image.blade.php
+++ b/resources/views/image.blade.php
@@ -26,7 +26,9 @@
             <img
                     {!! $attributes ?? '' !!}
                     class="{{ $class }}"
-                    style="background-image: url('{{ $presets['placeholder'] }}'); background-size: contain; background-position: center; background-repeat: no-repeat;"
+                    @if($presets['placeholder'] ?? false)
+                        style="background-image: url('{{ $presets['placeholder'] }}'); background-size: contain; background-position: center; background-repeat: no-repeat;"
+                    @endif                    ]
                     src="{{ $presets['placeholder'] ?? $image->url() }}"
                     alt="{{ $alt ?? $image->alt() }}"
                     width="{{ $width }}"

--- a/resources/views/partials/head.blade.php
+++ b/resources/views/partials/head.blade.php
@@ -1,14 +1,18 @@
 <script>
-    window.responsiveResizeObserver = new ResizeObserver((entries) => {
-        entries.forEach(entry => {
-            const bounds = entry.target.getBoundingClientRect();
-            const imgWidth = bounds.width;
-            const imgHeight = bounds.height;
-            const pixelRatio = window.devicePixelRatio * imgWidth;
-            
-            requestAnimationFrame(() => entry.target.parentNode.querySelectorAll('source').forEach((source) => {
-                source.sizes = pixelRatio + 'px';
-            }));
+window.responsiveResizeObserver = new ResizeObserver(async (entries) => {
+    entries.forEach(entry => {
+        let imgWidth = entry.devicePixelContentBoxSize[0].inlineSize;
+
+        if (imgWidth === 0) {
+            return;
+        }
+        
+        requestAnimationFrame(() => {
+            entry.target.loading = 'lazy';
+            entry.target.parentNode.querySelectorAll('source').forEach((source) => {
+                source.sizes = imgWidth + 'px'
+            })
         });
-    });
+    })
+});
 </script>


### PR DESCRIPTION
We do not need the bounds because ResizeObserver passes `devicePixelContentBoxSize` along with the bounds, WITH dpi factored in!

Previously the eager loaded images are render blocking when downloading the new image:
![image](https://github.com/user-attachments/assets/7791785c-9373-4fd3-a075-619de27238c5)

Now by setting loading to lazy before, pushes those downloads to the background:
![image](https://github.com/user-attachments/assets/63007d82-89c3-4902-b92f-cde76d54566d)

So your onload is much quicker.

Currently as draft, as in my current testing scenario i get a flash of white on my images while they load (Not impacting pagespeed might i add)