### PR TITLE
Fallback if entry is missing

### DIFF
--- a/resources/views/partials/head.blade.php
+++ b/resources/views/partials/head.blade.php
@@ -1,7 +1,7 @@
 <script>
 window.responsiveResizeObserver = new ResizeObserver(async (entries) => {
     entries.forEach(entry => {
-        let imgWidth = entry.devicePixelContentBoxSize[0].inlineSize;
+        let imgWidth = entry?.devicePixelContentBoxSize?.[0]?.inlineSize || 0;
 
         if (imgWidth === 0) {
             return;


### PR DESCRIPTION
In cases the user has navigated away while the observer is triggered it could've broken. This fixes that