### PR TITLE
Check for parent node before using it

### DIFF
--- a/resources/views/partials/head.blade.php
+++ b/resources/views/partials/head.blade.php
@@ -8,6 +8,10 @@ window.responsiveResizeObserver = new ResizeObserver(async (entries) => {
         }
         
         requestAnimationFrame(() => {
+            if (!entry?.target?.parentNode) {
+                return
+            }
+            
             entry.target.parentNode.querySelectorAll('source').forEach((source) => {
                 source.sizes = imgWidth + 'px'
             })


### PR DESCRIPTION
Under some circumstances you end up getting an error here because a target without parentNode (somehow) ends up getting resized. Theoretically this should be caught by the `imgWidth === 0` check but apparently this is not the case.