### PR TITLE
Fix empty srcset w rows

### DIFF
--- a/src/Responsive.php
+++ b/src/Responsive.php
@@ -68,6 +68,10 @@ class Responsive
         $index = 0;
 
         foreach ($configPresets as $preset => $data) {
+            if(!($data['w'] ?? false)) {
+                continue;
+            }
+
             $size = $data['w'].'w';
 
             if ($index < (count($configPresets) - 1)) {

--- a/tests/ResponsiveTest.php
+++ b/tests/ResponsiveTest.php
@@ -23,6 +23,7 @@ class ResponsiveTest extends TestCase
             'placeholder' => ['w' => 32, 'h' => 32, 'q' => 100, 'fit' => 'contain'],
             'xs' => ['w' => 320, 'h' => 320, 'q' => 100, 'fit' => 'contain'],
             'sm' => ['w' => 640, 'h' => 640, 'q' => 100, 'fit' => 'contain'],
+            'sm-h' => ['w' => null, 'h' => 640, 'q' => 100, 'fit' => 'contain'],
         ]);
     }
 
@@ -103,6 +104,29 @@ class ResponsiveTest extends TestCase
         $this->assertStringContainsString('src="', $rendered);
         $this->assertStringContainsString('.png', $rendered);
 
+        $asset->delete();
+    }
+
+    #[Test]
+    public function it_creates_mime_type_source_when_configured(): void
+    {
+        $asset = $this->uploadTestAsset('upload.png');
+        config()->set('justbetter.glide-directive.sources', 'mime_type');
+        
+        $view = Responsive::handle($asset);
+        /* @phpstan-ignore-next-line */
+        $rendered = $view->render();
+
+        $this->assertStringNotContainsString('<source type="image/webp"', $rendered);
+        
+        config()->set('justbetter.glide-directive.sources', 'webp');
+        
+        $view = Responsive::handle($asset);
+        /* @phpstan-ignore-next-line */
+        $rendered = $view->render();
+        
+        $this->assertStringNotContainsString('<source type="image/png"', $rendered);
+        
         $asset->delete();
     }
 }


### PR DESCRIPTION
When adding presets it's possible to keep the width on null, for example:
`'smallProduct' => ['h' => 406, 'w' => null, 'fm' => 'webp', 'fit' => 'crop_focal'],`

Before adding this check this could result in the following srcset being created:
<img width="1114" alt="Screenshot 2025-04-15 at 08 38 33" src="https://github.com/user-attachments/assets/6043ceb6-dbc7-4b50-9550-f87d741402c2" />
This would add sources with an empty width.

This PR fixes that problem.