### PR TITLE
Changed the way of loading placeholders

### DIFF
--- a/resources/views/image.blade.php
+++ b/resources/views/image.blade.php
@@ -13,21 +13,21 @@
                 @if(isset($presets['webp']))
                     <source
                         srcset="{{ $presets['webp'] }}"
-                        sizes="32px"
+                        sizes="100vw"
                         type="image/webp"
                     >
                 @endif
                 @if(isset($presets[$image->mimeType()]) && $image->mimeType() !== 'image/webp')
                     <source
                         srcset="{{ $presets[$image->mimeType()] }}"
-                        sizes="32px"
+                        sizes="100vw"
                         type="{{ $image->mimeType() }}"
                     >
                 @endif
                 <img
                         {!! $attributes ?? '' !!}
                         class="{{ $class }}"
-                        src="{{ $default_preset ?? $image->url() }}"
+                        src="{{ $presets['placeholder'] ?? $default_preset ?? $image->url() }}"
                         alt="{{ $alt ?? $image->alt() }}"
                         width="{{ $width }}"
                         height="{{ $height }}"

--- a/resources/views/image.blade.php
+++ b/resources/views/image.blade.php
@@ -13,14 +13,14 @@
                 @if(isset($presets['webp']))
                     <source
                         srcset="{{ $presets['webp'] }}"
-                        sizes="100vw"
+                        sizes="32px"
                         type="image/webp"
                     >
                 @endif
                 @if(isset($presets[$image->mimeType()]) && $image->mimeType() !== 'image/webp')
                     <source
                         srcset="{{ $presets[$image->mimeType()] }}"
-                        sizes="100vw"
+                        sizes="32px"
                         type="{{ $image->mimeType() }}"
                     >
                 @endif

--- a/resources/views/image.blade.php
+++ b/resources/views/image.blade.php
@@ -27,7 +27,7 @@
                 <img
                         {!! $attributes ?? '' !!}
                         class="{{ $class }}"
-                        src="{{ $presets['placeholder'] ?? $default_preset ?? $image->url() }}"
+                        src="{{ $default_preset ?? $image->url() }}"
                         alt="{{ $alt ?? $image->alt() }}"
                         width="{{ $width }}"
                         height="{{ $height }}"

--- a/routes/web.php
+++ b/routes/web.php
@@ -13,7 +13,7 @@ $patterns = [
 ];
 
 Route::get(
-    config('justbetter.glide-directive.cache_prefix').'/'.config('justbetter.glide-directive.storage_prefix').'/{preset}/{fit}/{s}/{file}{format}',
+    config('justbetter.glide-directive.cache_prefix').'/'.config('justbetter.glide-directive.storage_prefix').'/{p}/{fit}/{s}/{file}{format}',
     [ImageController::class, 'getImageByPreset']
 )
     ->where($patterns)

--- a/src/Controllers/ImageController.php
+++ b/src/Controllers/ImageController.php
@@ -27,7 +27,7 @@ class ImageController extends Controller
     public function getImageByPreset(Request $request, string $preset, string $fit, string $signature, string $file, string $format): BinaryFileResponse
     {
         $this->asset = AssetFacade::findByUrl(Str::start($file, '/'));
-        $this->params = ['s' => $signature, 'preset' => $preset, 'fit' => $fit, 'format' => $format];
+        $this->params = ['s' => $signature, 'p' => $preset, 'fit' => $fit, 'format' => $format];
 
         if (! $this->asset) {
             abort(404);
@@ -65,7 +65,7 @@ class ImageController extends Controller
 
         $this->server->setSource(Storage::build(['driver' => 'local', 'root' => public_path()])->getDriver());
         $this->server->setSourcePathPrefix('/');
-        $this->server->setCachePathPrefix(config('justbetter.glide-directive.storage_prefix', 'glide-image').'/'.$this->params['preset'].'/'.$this->params['fit'].'/'.$this->params['s']);
+        $this->server->setCachePathPrefix(config('justbetter.glide-directive.storage_prefix', 'glide-image').'/'.$this->params['p'].'/'.$this->params['fit'].'/'.$this->params['s']);
         $this->server->setCachePathCallable($this->getCachePathCallable());
 
         $path = $this->server->makeImage($this->asset->url(), $this->params);
@@ -86,5 +86,4 @@ class ImageController extends Controller
         return function () use ($server, $asset, $params) {
             return $server->getCachePathPrefix().$asset->url().$params['format'];
         };
-    }
-}
+    }}

--- a/src/Responsive.php
+++ b/src/Responsive.php
@@ -153,7 +153,7 @@ class Responsive
         }
 
         $signatureFactory = SignatureFactory::create(config('app.key'));
-        $params = $signatureFactory->addSignature($asset->url(), ['preset' => $preset, 'fit' => $fit, 'format' => '.'.$format]);
+        $params = $signatureFactory->addSignature($asset->url(), ['p' => $preset, 'fit' => $fit, 'format' => '.'.$format]);
 
         return route('glide-image.preset', array_merge($params, [
             'file' => ltrim($asset->url(), '/'),

--- a/tests/Controllers/ImageControllerTest.php
+++ b/tests/Controllers/ImageControllerTest.php
@@ -92,7 +92,7 @@ class ImageControllerTest extends TestCase
 
         $params = [
             's' => '',
-            'preset' => 'xs',
+            'p' => 'xs',
             'fit' => 'contain',
             'format' => '.webp',
         ];
@@ -148,7 +148,7 @@ class ImageControllerTest extends TestCase
         $signatureFactory = new \League\Glide\Signatures\Signature(config('app.key'));
         $params = [
             's' => '',
-            'preset' => 'md',
+            'p' => 'md',
             'fit' => 'crop',
             'format' => '.jpg',
         ];


### PR DESCRIPTION
Switched the `<source>` sizes from `32px` to `100vw` and set the `<img src>` back to a tiny data-URI placeholder.
This prevents the browser from eagerly fetching the full image and lets it pick the right size up front, after the load the ResizeObserver refines the rest of the sizes.