### PR TITLE
Fix image alt

### DIFF
--- a/resources/views/image.blade.php
+++ b/resources/views/image.blade.php
@@ -5,7 +5,7 @@
                 <img
                     class="{{ $class }}"
                     src="{{ $image->url() }}"
-                    alt="{{ $alt }}"
+                    alt="{{ $alt ?: ($image->get('alt') ?? '') }}"
                     width="{{ $width }}"
                     height="{{ $height }}"
                 />
@@ -28,7 +28,7 @@
                         {!! $attributes ?? '' !!}
                         class="{{ $class }}"
                         src="{{ $default_preset ?? $image->url() }}"
-                        alt="{{ $alt ?? $image->alt() }}"
+                        alt="{{ $alt ?: ($image->get('alt') ?? '') }}"
                         width="{{ $width }}"
                         height="{{ $height }}"
                         loading="lazy"
@@ -44,7 +44,7 @@
             {!! $attributes ?? '' !!}
             class="{{ $class }}"
             src="{{ $image->url() }}"
-            alt="{{ $alt ?? $image->alt() }}"
+            alt="{{ $alt ?: ($image->get('alt') ?? '') }}"
             width="{{ $width }}"
             height="{{ $height }}"
             loading="lazy"

--- a/resources/views/image.blade.php
+++ b/resources/views/image.blade.php
@@ -5,7 +5,7 @@
                 <img
                     class="{{ $class }}"
                     src="{{ $image->url() }}"
-                    alt="{{ $alt ?: ($image->get('alt') ?? '') }}"
+                    alt="{{ $alt }}"
                     width="{{ $width }}"
                     height="{{ $height }}"
                 />
@@ -28,7 +28,7 @@
                         {!! $attributes ?? '' !!}
                         class="{{ $class }}"
                         src="{{ $default_preset ?? $image->url() }}"
-                        alt="{{ $alt ?: ($image->get('alt') ?? '') }}"
+                        alt="{{ $alt }}"
                         width="{{ $width }}"
                         height="{{ $height }}"
                         loading="lazy"
@@ -44,7 +44,7 @@
             {!! $attributes ?? '' !!}
             class="{{ $class }}"
             src="{{ $image->url() }}"
-            alt="{{ $alt ?: ($image->get('alt') ?? '') }}"
+            alt="{{ $alt }}"
             width="{{ $width }}"
             height="{{ $height }}"
             loading="lazy"

--- a/src/Responsive.php
+++ b/src/Responsive.php
@@ -29,7 +29,7 @@ class Responsive
             'presets' => self::getPresets($asset),
             'attributes' => self::getAttributeBag($arguments),
             'class' => $arguments['class'] ?? '',
-            'alt' => $arguments['alt'] ?? '',
+            'alt' => $arguments['alt'] ?: ($asset->get('alt') ?? ''),
             'width' => $arguments['width'] ?? $asset->width(),
             'height' => $arguments['height'] ?? $asset->height(),
         ]);

--- a/src/Responsive.php
+++ b/src/Responsive.php
@@ -29,7 +29,7 @@ class Responsive
             'presets' => self::getPresets($asset),
             'attributes' => self::getAttributeBag($arguments),
             'class' => $arguments['class'] ?? '',
-            'alt' => $arguments['alt'] ?: ($asset->get('alt') ?? ''),
+            'alt' => $arguments['alt'] ?? ($asset->get('alt') ?? ''),
             'width' => $arguments['width'] ?? $asset->width(),
             'height' => $arguments['height'] ?? $asset->height(),
         ]);


### PR DESCRIPTION
It seems like it's no longer possible to call the `alt()` method to get the alt data of an image. Instead, you have to fetch it from the data using `$asset->get('alt')`.
I've updated the directive to first check for alt tags passed directly like `@responsive($asset, ['alt' => 'some alt text'])`. If that's empty or not provided, it will fall back to getting the alt text from the image itself.