### PR TITLE
Use right width for sizes

### DIFF
--- a/resources/views/partials/head.blade.php
+++ b/resources/views/partials/head.blade.php
@@ -2,10 +2,9 @@
 window.responsiveResizeObserver = new ResizeObserver(async (entries) => {
     entries.forEach(entry => {
         let imgWidth = null
-        imgWidth ||= entry?.devicePixelContentBoxSize?.[0]?.inlineSize
-        imgWidth ||= entry?.borderBoxSize?.[0]?.inlineSize * window.devicePixelRatio
-        imgWidth ||= entry?.contentBoxSize?.[0]?.inlineSize * window.devicePixelRatio
-        imgWidth ||= entry?.contentRect?.width * window.devicePixelRatio
+        imgWidth ||= entry?.contentRect?.width
+        imgWidth ||= entry?.borderBoxSize?.[0]?.inlineSize
+        imgWidth ||= entry?.contentBoxSize?.[0]?.inlineSize
 
         if (!imgWidth) {
             return;
@@ -18,8 +17,8 @@ window.responsiveResizeObserver = new ResizeObserver(async (entries) => {
             
             entry.target.parentNode.querySelectorAll('source').forEach((source) => {
                 source.sizes = imgWidth + 'px'
-            })
+            });
         });
-    })
+    });
 });
 </script>


### PR DESCRIPTION
So i did some research on how this whole picture tag / source / sizes / sources work and this is my conclusion:

The browser will:
* First check the type of source within the picture tag => does the browser support "image/webp"
* If it does it will check that `<source>` tag for the sizes="x" attribute. 
* **The browser** will calculate a target resource width so:
** If your device is 1x DPR (standard screen): target = x * 1 = xw
** If your device is 2x DPR (Retina): target = x * 2 = xw
** If your device is 3x DPR: target x * 3 = xw
** Where the x is the sizes attributes

We previously thought this funcionality needed to be done ourselves with: `<width> * window.devicePixelRatio`. When reality is the browser does that for us.