### PR TITLE
Open up getGlideUrl function

### DIFF
--- a/src/Responsive.php
+++ b/src/Responsive.php
@@ -145,7 +145,7 @@ class Responsive
         );
     }
 
-    protected static function getGlideUrl(Asset $asset, string $preset, string $fit, ?string $format = null): ?string
+    public static function getGlideUrl(Asset $asset, string $preset, string $fit, ?string $format = null): ?string
     {
         if ($preset === 'placeholder') {
             return Statamic::tag('glide:data_url')->params([


### PR DESCRIPTION
This way the on-the-fly image generator can also be used for a single image preset instead of the entire list of sizes