### PR TITLE
[3.x] Optimizations cropping and resizing

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,10 +9,10 @@
     "require-dev": {
         "larastan/larastan": "^3.4",
         "laravel/pint": "^1.22",
-        "orchestra/testbench": "^10.3",
-        "pestphp/pest": "^3.7",
+        "orchestra/testbench": "^9.10",
+        "pestphp/pest": "^2.36",
         "phpstan/phpstan-mockery": "^2.0",
-        "phpunit/phpunit": "^11.5"
+        "phpunit/phpunit": "^10.5"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -58,7 +58,7 @@
         "test": "phpunit",
         "analyse": "phpstan --memory-limit=1G",
         "style": "pint --test",
-        "coverage": "XDEBUG_MODE=coverage php vendor/bin/pest --coverage --min=93",
+        "coverage": "XDEBUG_MODE=coverage php vendor/bin/pest --coverage --min=100",
         "quality": [
             "@test",
             "@analyse",

--- a/composer.json
+++ b/composer.json
@@ -9,10 +9,10 @@
     "require-dev": {
         "larastan/larastan": "^3.4",
         "laravel/pint": "^1.22",
-        "orchestra/testbench": "^9.10",
-        "pestphp/pest": "^2.36",
+        "orchestra/testbench": "^10.11|^11.0",
+        "pestphp/pest": "^3.0",
         "phpstan/phpstan-mockery": "^2.0",
-        "phpunit/phpunit": "^10.5"
+        "phpunit/phpunit": "^11.5"
     },
     "autoload": {
         "psr-4": {

--- a/config/glide-directive.php
+++ b/config/glide-directive.php
@@ -1,25 +1,14 @@
 <?php
 
 return [
-    // The default preset used in the img src.
-    'default_preset' => 'md',
-
     // The default widths used for generating the resizes.
-    'default_widths' => [320, 480, 640, 768, 1024, 1280, 1440, 1536, 1680],
+    'default_widths' => [320, 480, 640, 768, 1024, 1280, 1440, 1536, 1680, 1920, 2048, 2560],
 
     // The default formats that are used for generating the resizes.
     'default_formats' => [
         'avif' => 'image/avif',
         'webp' => 'image/webp',
         'jpg' => 'image/jpeg',
-    ],
-
-    'sizes' => [
-        'xs' => '(min-width: 768px) 320px, (min-width: 640px) 80vw, 90vw',
-        'sm' => '(min-width: 768px) 480px, (min-width: 640px) 85vw, 90vw',
-        'md' => '(min-width: 1280px) 640px, (min-width: 768px) 50vw, 90vw',
-        'lg' => '(min-width: 1280px) 960px, (min-width: 768px) 75vw, 90vw',
-        'xl' => '(min-width: 1280px) 1150px, 90vw',
     ],
 
     // Set the cache prefix to use for the image source sets.

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -6,6 +6,9 @@
         </testsuite>
     </testsuites>
     <coverage/>
+    <php>
+        <env name="APP_KEY" value="base64:6G5y27wtEh59FK7Xnc8Yn22TxSt2eYuZpnQsQY2Sjls="/>
+    </php>
     <source>
         <include>
             <directory suffix=".php">./src</directory>

--- a/resources/views/image.blade.php
+++ b/resources/views/image.blade.php
@@ -13,7 +13,7 @@
             <source
                 type="image/{{ $type }}"
                 srcset="{{ implode(', ', $srcset) }}"
-                sizes="{{ config('justbetter.glide-directive.sizes')[$size] }}"
+                sizes="{{ $sizes ?? '100vw'}}"
             >
         @endforeach
 
@@ -24,8 +24,8 @@
             width="{{ $width }}"
             height="{{ $height }}"
             loading="lazy"
-            class="{{ $classAttr ?? '' }}"
             {!! $styleAttr ?? '' !!}
+            class="{{ $class }}"
         />
     @endif
 </picture>

--- a/src/Controllers/ImageController.php
+++ b/src/Controllers/ImageController.php
@@ -31,18 +31,26 @@ class ImageController extends Controller
     ): BinaryFileResponse {
         $file = ltrim($file, '/');
         $format = ltrim($format, '.');
-
         $this->asset = AssetFacade::findByUrl('/'.$file);
-
-        $this->params = [
-            's' => $signature,
-            'width' => $width,
-            'height' => $height,
-            'format' => $format,
-        ];
 
         if (! $this->asset) {
             abort(404);
+        }
+
+        $this->params = [
+            'w' => $width,
+            'h' => $height,
+            'fm' => $format,
+            'q' => 85,
+            's' => $signature,
+        ];
+
+        if ($request->has('crop')) {
+            $this->params['fit'] = 'crop-center';
+        }
+
+        if ($this->asset->has('focus')) {
+            $this->params['fit'] = 'crop-'.$this->asset->get('focus');
         }
 
         try {
@@ -82,17 +90,6 @@ class ImageController extends Controller
             return null;
         }
 
-        $params = [
-            'w' => $this->params['width'],
-            'fm' => $this->params['format'],
-            'q' => 85,
-        ];
-
-        if (! empty($this->params['height'])) {
-            $params['h'] = $this->params['height'];
-            $params['fit'] = 'crop-focal';
-        }
-
         $source = Storage::build([
             'driver' => 'local',
             'root' => public_path(),
@@ -117,7 +114,7 @@ class ImageController extends Controller
             fn (string $path, array $params) => $expectedRelativePath
         );
 
-        $generated = $this->server->makeImage($this->asset->url(), $params);
+        $generated = $this->server->makeImage($this->asset->url(), $this->params);
 
         return $cacheRoot.'/'.ltrim($generated, '/');
     }
@@ -130,10 +127,10 @@ class ImageController extends Controller
 
     protected function getCachePathInsideCacheRoot(): string
     {
-        $width = (int) $this->params['width'];
-        $height = (int) $this->params['height'];
+        $width = (int) $this->params['w'];
+        $height = (int) $this->params['h'];
         $signature = trim($this->params['s'], '/');
-        $format = ltrim($this->params['format'], '.');
+        $format = ltrim($this->params['fm'], '.');
 
         $assetUrl = ltrim($this->asset?->url() ?? '', '/');
 
@@ -150,7 +147,7 @@ class ImageController extends Controller
 
     protected function getContentType(): string
     {
-        return match (strtolower($this->params['format'])) {
+        return match (strtolower($this->params['fm'])) {
             'jpg', 'jpeg' => 'image/jpeg',
             'png' => 'image/png',
             'gif' => 'image/gif',

--- a/src/Controllers/ImageController.php
+++ b/src/Controllers/ImageController.php
@@ -49,8 +49,10 @@ class ImageController extends Controller
             $this->params['fit'] = 'crop-center';
         }
 
-        if ($this->asset->has('focus')) {
-            $this->params['fit'] = 'crop-'.$this->asset->get('focus');
+        $focus = $this->asset instanceof Asset ? $this->asset->get('focus') : null;
+
+        if ($focus) {
+            $this->params['fit'] = 'crop-'.$focus;
         }
 
         try {

--- a/src/Responsive.php
+++ b/src/Responsive.php
@@ -59,17 +59,17 @@ class Responsive
         $srcsetParts = [];
         foreach ($formats as $format => $mimeType) {
             $srcsetParts[$format] = [];
-            
-                $url = self::getGlideUrl($asset, $width, $height, $format);
 
-                $url = url()->query($url, ['crop' => 1]);
-                $srcsetParts[$format][] = "{$url} {$width}w";
+            $url = self::getGlideUrl($asset, $width, $height, $format);
 
-                $url = self::getGlideUrl($asset, $width * 2, $height * 2, $format);
-                $url = url()->query($url, ['crop' => 1]);
+            $url = url()->query($url, ['crop' => 1]);
+            $srcsetParts[$format][] = "{$url} {$width}w";
 
-                $width = $width * 2;
-                $srcsetParts[$format][] = "{$url} {$width}w";
+            $url = self::getGlideUrl($asset, $width * 2, $height * 2, $format);
+            $url = url()->query($url, ['crop' => 1]);
+
+            $width = $width * 2;
+            $srcsetParts[$format][] = "{$url} {$width}w";
         }
 
         return $srcsetParts;
@@ -84,15 +84,13 @@ class Responsive
         return self::getSrcsets($asset, $ratio);
     }
 
-    protected static function getSrcSets(Asset $asset, ?float $ratio)
+    protected static function getSrcSets(Asset $asset, ?float $ratio): array
     {
         $formats = config('justbetter.glide-directive.default_formats');
-        $originalRatio = $asset->height() && $asset->width()
-            ? $asset->height() / $asset->width()
-            : null;
+        $originalRatio = $asset->ratio();
 
         $useRatio = $ratio ?? $originalRatio;
-
+        $srcsetParts = [];
 
         foreach ($formats as $format => $mimeType) {
             $srcsetParts[$format] = [];
@@ -129,7 +127,7 @@ class Responsive
         ]);
     }
 
-    public static function getGlideUrl(Asset $asset, int $width, ?int $height, string $format): ?string
+    public static function getGlideUrl(Asset $asset, int $width, ?int $height, string $format): string
     {
         $signatureFactory = SignatureFactory::create(config('app.key'));
 

--- a/src/Responsive.php
+++ b/src/Responsive.php
@@ -20,18 +20,10 @@ class Responsive
             return '';
         }
 
-        $size = $arguments['size'] ?? config('justbetter.glide-directive.default_preset');
+        $sizes = $arguments['sizes'] ?? config('justbetter.glide-directive.sizes_default');
         $focus = $asset->get('focus');
-        $cover = isset($arguments['cover']);
-        $contain = isset($arguments['contain']);
 
-        $classAttr = match (true) {
-            $cover => 'object-cover w-full h-full object-[var(--focal-point)]'.(isset($arguments['class']) ? ' '.e($arguments['class']) : ''),
-            $contain => 'object-contain w-full h-full object-[var(--focal-point)]'.(isset($arguments['class']) ? ' '.e($arguments['class']) : ''),
-            default => e($arguments['class'] ?? ''),
-        };
-
-        if (($cover || $contain) || is_string($focus)) {
+        if (is_string($focus)) {
             $styleAttr = sprintf(' style="object-position: %s"', self::focusToPosition($focus));
         }
 
@@ -40,15 +32,14 @@ class Responsive
 
         return view($view, [
             'image' => $asset,
-            'srcsets' => self::buildSrcsets($asset, $arguments['ratio'] ?? null),
+            'srcsets' => self::buildSrcsets($asset, $arguments['ratio'] ?? null, $arguments['width'] ?? null, $arguments['height'] ?? null),
             'attributes' => self::getAttributeBag($arguments),
             'class' => $arguments['class'] ?? '',
             'alt' => $arguments['alt'] ?? ($asset->get('alt') ?? ''),
             'width' => $arguments['width'] ?? $asset->width(),
             'height' => $arguments['height'] ?? $asset->height(),
-            'classAttr' => $classAttr,
             'styleAttr' => $styleAttr ?? '',
-            'size' => $size,
+            'sizes' => $sizes,
         ]);
     }
 
@@ -61,16 +52,48 @@ class Responsive
         return vsprintf('%d%% %d%%', explode('-', $focus));
     }
 
-    protected static function buildSrcsets(Asset $asset, ?float $ratio): array
+    protected static function cropAndResize(Asset $asset, int $width, int $height): array
     {
+        $formats = config('justbetter.glide-directive.default_formats');
+
+        $srcsetParts = [];
+        foreach ($formats as $format => $mimeType) {
+            $srcsetParts[$format] = [];
+            
+                $url = self::getGlideUrl($asset, $width, $height, $format);
+
+                $url = url()->query($url, ['crop' => 1]);
+                $srcsetParts[$format][] = "{$url} {$width}w";
+
+                $url = self::getGlideUrl($asset, $width * 2, $height * 2, $format);
+                $url = url()->query($url, ['crop' => 1]);
+
+                $width = $width * 2;
+                $srcsetParts[$format][] = "{$url} {$width}w";
+        }
+
+        return $srcsetParts;
+    }
+
+    protected static function buildSrcsets(Asset $asset, ?float $ratio, ?int $width = null, ?int $height = null): array
+    {
+        if ($width && $height) {
+            return self::cropAndResize($asset, $width, $height);
+        }
+
+        return self::getSrcsets($asset, $ratio);
+    }
+
+    protected static function getSrcSets(Asset $asset, ?float $ratio)
+    {
+        $formats = config('justbetter.glide-directive.default_formats');
         $originalRatio = $asset->height() && $asset->width()
             ? $asset->height() / $asset->width()
             : null;
 
         $useRatio = $ratio ?? $originalRatio;
 
-        $formats = config('justbetter.glide-directive.default_formats');
-        $srcsetParts = [];
+
         foreach ($formats as $format => $mimeType) {
             $srcsetParts[$format] = [];
 

--- a/tests/Controllers/ImageControllerTest.php
+++ b/tests/Controllers/ImageControllerTest.php
@@ -156,10 +156,10 @@ class ImageControllerTest extends TestCase
         $signature = $signatureFactory->generateSignature($asset->url(), $params);
 
         $storagePrefix = config('justbetter.glide-directive.storage_prefix');
-        $imagePath = $storagePrefix.'/350/500/'.$signature.$asset->url().'.jpg';
+        $imagePath = $storagePrefix . '/350/500/' . $signature . $asset->url() . '.jpg';
 
         /** @var Server $server */
-        $server = $this->mock(Server::class, function (MockInterface $mock) use ($asset, $imagePath) {
+        $server = $this->mock(Server::class, function (MockInterface $mock) use ($asset, $imagePath, $signature) {
             $mock->shouldReceive('setSource')->andReturnSelf();
             $mock->shouldReceive('setSourcePathPrefix')->andReturnSelf();
             $mock->shouldReceive('setCache')->andReturnSelf();
@@ -167,13 +167,17 @@ class ImageControllerTest extends TestCase
             $mock->shouldReceive('setCachePathCallable')->andReturnSelf();
 
             $mock->shouldReceive('makeImage')
-                ->with($asset->url(), ['w' => 350, 'fm' => 'jpg', 'h' => 500, 'q' => 85, 'fit' => 'crop-focal'])
+                ->with($asset->url(), [
+                    'w' => 350,
+                    'h' => 500,
+                    'fm' => 'jpg',
+                    'q' => 85,
+                    's' => $signature,
+                ])
                 ->andReturn($imagePath);
         });
 
-        $controller = new ImageController(
-            $server
-        );
+        $controller = new ImageController($server);
 
         $this->expectException(NotFoundHttpException::class);
 

--- a/tests/Controllers/ImageControllerTest.php
+++ b/tests/Controllers/ImageControllerTest.php
@@ -156,7 +156,7 @@ class ImageControllerTest extends TestCase
         $signature = $signatureFactory->generateSignature($asset->url(), $params);
 
         $storagePrefix = config('justbetter.glide-directive.storage_prefix');
-        $imagePath = $storagePrefix . '/350/500/' . $signature . $asset->url() . '.jpg';
+        $imagePath = $storagePrefix.'/350/500/'.$signature.$asset->url().'.jpg';
 
         /** @var Server $server */
         $server = $this->mock(Server::class, function (MockInterface $mock) use ($asset, $imagePath, $signature) {
@@ -189,6 +189,129 @@ class ImageControllerTest extends TestCase
             ltrim($asset->url(), '/'),
             '.jpg'
         );
+    }
+
+    #[Test]
+    public function it_returns_generated_images_when_they_are_built(): void
+    {
+        $asset = $this->uploadTestAsset('upload.png');
+        $asset->set('focus', '25-75');
+        $asset->save();
+
+        $signatureFactory = new Signature(config('app.key'));
+        $params = [
+            's' => '',
+            'width' => 350,
+            'height' => 500,
+            'format' => '.jpg',
+        ];
+
+        $signature = $signatureFactory->generateSignature($asset->url(), $params);
+        $generatedPath = config('justbetter.glide-directive.cache_prefix')
+            .'/'.config('justbetter.glide-directive.storage_prefix')
+            .'/generated/image.jpg';
+
+        $directory = dirname(public_path($generatedPath));
+        if (! is_dir($directory)) {
+            mkdir($directory, 0755, true);
+        }
+
+        file_put_contents(public_path($generatedPath), 'fake-image-content');
+
+        /** @var Server $server */
+        $server = $this->mock(Server::class, function (MockInterface $mock) use ($asset, $signature) {
+            $mock->shouldReceive('setSource')->andReturnSelf();
+            $mock->shouldReceive('setSourcePathPrefix')->andReturnSelf();
+            $mock->shouldReceive('setCache')->andReturnSelf();
+            $mock->shouldReceive('setCachePathPrefix')->andReturnSelf();
+            $mock->shouldReceive('setCachePathCallable')->andReturnSelf();
+
+            $mock->shouldReceive('makeImage')
+                ->with($asset->url(), [
+                    'w' => 350,
+                    'h' => 500,
+                    'fm' => 'jpg',
+                    'q' => 85,
+                    's' => $signature,
+                    'fit' => 'crop-25-75',
+                ])
+                ->andReturn('generated/image.jpg');
+        });
+
+        $request = request();
+        $request->merge(['crop' => 1]);
+
+        try {
+            $response = (new ImageController($server))->getImageByPreset(
+                $request,
+                350,
+                500,
+                $signature,
+                ltrim($asset->url(), '/'),
+                '.jpg'
+            );
+
+            $this->assertInstanceOf(BinaryFileResponse::class, $response);
+            $this->assertEquals('image/jpeg', $response->headers->get('Content-Type'));
+        } finally {
+            if (file_exists(public_path($generatedPath))) {
+                unlink(public_path($generatedPath));
+            }
+        }
+    }
+
+    #[Test]
+    public function it_returns_content_types_for_cached_images(): void
+    {
+        $asset = $this->uploadTestAsset('upload.png');
+        $signatureFactory = new Signature(config('app.key'));
+
+        $formats = [
+            '.jpeg' => 'image/jpeg',
+            '.png' => 'image/png',
+            '.gif' => 'image/gif',
+            '.avif' => 'image/avif',
+        ];
+
+        foreach ($formats as $format => $contentType) {
+            $params = [
+                's' => '',
+                'width' => 350,
+                'height' => 500,
+                'format' => $format,
+            ];
+
+            $signature = $signatureFactory->generateSignature($asset->url(), $params);
+            $expectedImagePath = public_path(
+                config('justbetter.glide-directive.cache_prefix')
+                .'/'.config('justbetter.glide-directive.storage_prefix')
+                .'/350/500/'.$signature.$asset->url().$format
+            );
+
+            $directory = dirname($expectedImagePath);
+            if (! is_dir($directory)) {
+                mkdir($directory, 0755, true);
+            }
+
+            file_put_contents($expectedImagePath, 'fake-image-content');
+
+            try {
+                $response = $this->controller->getImageByPreset(
+                    request(),
+                    350,
+                    500,
+                    $signature,
+                    ltrim($asset->url(), '/'),
+                    $format
+                );
+
+                $this->assertEquals($contentType, $response->headers->get('Content-Type'));
+            } finally {
+                if (file_exists($expectedImagePath)) {
+                    unlink($expectedImagePath);
+                }
+            }
+        }
     }
 
     #[Test]

--- a/tests/Listeners/GlideCacheClearedListenerTest.php
+++ b/tests/Listeners/GlideCacheClearedListenerTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace JustBetter\GlideDirective\Tests\Listeners;
+
+use Illuminate\Cache\Repository;
+use JustBetter\GlideDirective\Listeners\GlideCacheClearedListener;
+use JustBetter\GlideDirective\Tests\TestCase;
+use Mockery\MockInterface;
+use PHPUnit\Framework\Attributes\Test;
+use Statamic\Events\GlideCacheCleared;
+use Statamic\Facades\Glide;
+
+class GlideCacheClearedListenerTest extends TestCase
+{
+    #[Test]
+    public function it_flushes_the_glide_cache_store(): void
+    {
+        $repository = $this->mock(Repository::class, function (MockInterface $mock): void {
+            $mock->shouldReceive('flush')->once();
+        });
+
+        Glide::shouldReceive('cacheStore')
+            ->once()
+            ->andReturn($repository);
+
+        app(GlideCacheClearedListener::class)->handle(new GlideCacheCleared);
+    }
+}

--- a/tests/ResponsiveTest.php
+++ b/tests/ResponsiveTest.php
@@ -73,6 +73,29 @@ class ResponsiveTest extends TestCase
     }
 
     #[Test]
+    public function it_converts_focus_values_to_object_position_styles(): void
+    {
+        $asset = $this->uploadTestAsset('upload.png');
+        $asset->set('focus', '25-75');
+
+        $view = Responsive::handle($asset);
+        /* @phpstan-ignore-next-line */
+        $rendered = $view->render();
+
+        $this->assertStringContainsString('style="object-position: 25% 75%"', $rendered);
+
+        $asset->set('focus', 'center');
+
+        $view = Responsive::handle($asset);
+        /* @phpstan-ignore-next-line */
+        $rendered = $view->render();
+
+        $this->assertStringContainsString('style="object-position: center"', $rendered);
+
+        $asset->delete();
+    }
+
+    #[Test]
     public function it_creates_mime_type_source_when_configured(): void
     {
         $asset = $this->uploadTestAsset('upload.png');

--- a/tests/ServiceProviderTest.php
+++ b/tests/ServiceProviderTest.php
@@ -20,7 +20,6 @@ class ServiceProviderTest extends TestCase
     {
         $this->assertNotNull(config('justbetter.glide-directive'));
         $this->assertIsArray(config('justbetter.glide-directive.default_widths'));
-        $this->assertIsArray(config('justbetter.glide-directive.sizes'));
         $this->assertIsArray(config('justbetter.glide-directive.default_formats'));
     }
 


### PR DESCRIPTION
This PR adds some optimizations. This will change the way the images are resized, loaded and cropped.

For an image that should be full width like a hero banner, we can just use the reponsive tag:

```
@responsive($set->image)
```

This will give the sources tag a sizes attribute of `100vw`. 

When we have an image that will always be (or kindoff) the same size, we can give a width and a height:

```@responsive($tile->image, ['width' => 295, 'height' => 240, 'sizes' => '(min-width: 768px) 295px, 100vw', 'loading' => 'lazy', 'fetchpriority' => 'low'])
```

Apart from the width and the height we can give a sizes attribute with a media query when to display what. As in this case on mobile we want to display the image full width.