### PR TITLE
Fixed ratio calculation

### DIFF
--- a/src/Responsive.php
+++ b/src/Responsive.php
@@ -96,7 +96,7 @@ class Responsive
             $srcsetParts[$format] = [];
 
             foreach (self::getWidths() as $width) {
-                $height = $useRatio ? (int) round($width * $useRatio) : null;
+                $height = $useRatio ? (int) round($width / $useRatio) : null;
 
                 $srcset = [
                     'width' => $width,


### PR DESCRIPTION
`Asset::ratio()` returns the image’s width divided by height. The old calculation multiplied the target width by that ratio, which inverted the intended dimensions for landscape images and generated portrait sized Glide URLs like 2560x3840. Dividing the width by the ratio gives the correct proportional height, for example `2560 / 1.5 = 1707`, preserving the original landscape aspect ratio and preventing unintended crop/zoom behavior.