### PR TITLE
Make glide directive work with private asset containers

### DIFF
--- a/src/Controllers/ImageController.php
+++ b/src/Controllers/ImageController.php
@@ -94,7 +94,7 @@ class ImageController extends Controller
 
         $source = Storage::build([
             'driver' => 'local',
-            'root' => public_path(),
+            'root' => $this->asset->disk()->path('/'),
         ]);
 
         $cacheRoot = $this->getPublicCacheRoot();
@@ -105,7 +105,7 @@ class ImageController extends Controller
         ]);
 
         $this->server->setSource($source->getDriver());
-        $this->server->setSourcePathPrefix('/');
+        $this->server->setSourcePathPrefix('');
 
         $this->server->setCache($cache->getDriver());
         $this->server->setCachePathPrefix('');
@@ -116,7 +116,7 @@ class ImageController extends Controller
             fn (string $path, array $params) => $expectedRelativePath
         );
 
-        $generated = $this->server->makeImage($this->asset->url(), $this->params);
+        $generated = $this->server->makeImage($this->asset->path(), $this->params);
 
         return $cacheRoot.'/'.ltrim($generated, '/');
     }

--- a/src/Controllers/ImageController.php
+++ b/src/Controllers/ImageController.php
@@ -94,6 +94,7 @@ class ImageController extends Controller
 
         $source = Storage::build([
             'driver' => 'local',
+            /* @phpstan-ignore-next-line */
             'root' => $this->asset->disk()->path('/'),
         ]);
 
@@ -116,6 +117,7 @@ class ImageController extends Controller
             fn (string $path, array $params) => $expectedRelativePath
         );
 
+        /* @phpstan-ignore-next-line */
         $generated = $this->server->makeImage($this->asset->path(), $this->params);
 
         return $cacheRoot.'/'.ltrim($generated, '/');

--- a/tests/Controllers/ImageControllerTest.php
+++ b/tests/Controllers/ImageControllerTest.php
@@ -183,7 +183,7 @@ class ImageControllerTest extends TestCase
             $mock->shouldReceive('setCachePathCallable')->andReturnSelf();
 
             $mock->shouldReceive('makeImage')
-                ->with($asset->url(), [
+                ->with($asset->path(), [
                     'w' => 350,
                     'h' => 500,
                     'fm' => 'jpg',
@@ -243,7 +243,7 @@ class ImageControllerTest extends TestCase
             $mock->shouldReceive('setCachePathCallable')->andReturnSelf();
 
             $mock->shouldReceive('makeImage')
-                ->with($asset->url(), [
+                ->with($asset->path(), [
                     'w' => 350,
                     'h' => 500,
                     'fm' => 'jpg',


### PR DESCRIPTION
As private assets don't have a url and still can be used, we should not use the public path or the url.