### PR TITLE
Fix error on file not found

### DIFF
--- a/src/Controllers/ImageController.php
+++ b/src/Controllers/ImageController.php
@@ -120,7 +120,7 @@ class ImageController extends Controller
         try {
             $generated = $this->server->makeImage($this->asset->url(), $this->params);
         } catch (FileNotFoundException $e) {
-            return null
+            return null;
         }
 
         return $cacheRoot.'/'.ltrim($generated, '/');

--- a/src/Controllers/ImageController.php
+++ b/src/Controllers/ImageController.php
@@ -116,6 +116,7 @@ class ImageController extends Controller
         $this->server->setCachePathCallable(
             fn (string $path, array $params) => $expectedRelativePath
         );
+
         try {
             $generated = $this->server->makeImage($this->asset->url(), $this->params);
         } catch (FileNotFoundException $e) {

--- a/src/Controllers/ImageController.php
+++ b/src/Controllers/ImageController.php
@@ -5,6 +5,7 @@ namespace JustBetter\GlideDirective\Controllers;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
 use Illuminate\Support\Facades\Storage;
+use League\Glide\Filesystem\FileNotFoundException;
 use League\Glide\Server;
 use League\Glide\Signatures\Signature;
 use League\Glide\Signatures\SignatureException;
@@ -115,8 +116,11 @@ class ImageController extends Controller
         $this->server->setCachePathCallable(
             fn (string $path, array $params) => $expectedRelativePath
         );
-
-        $generated = $this->server->makeImage($this->asset->url(), $this->params);
+        try {
+            $generated = $this->server->makeImage($this->asset->url(), $this->params);
+        } catch (FileNotFoundException $e) {
+            return null
+        }
 
         return $cacheRoot.'/'.ltrim($generated, '/');
     }

--- a/tests/Controllers/ImageControllerTest.php
+++ b/tests/Controllers/ImageControllerTest.php
@@ -211,7 +211,7 @@ class ImageControllerTest extends TestCase
     public function it_returns_404_when_asset_exists_but_file_is_missing(): void
     {
         $asset = $this->uploadTestAsset('upload_404.png');
-        @unlink($this->assetPath('upload_404.png'));
+        @unlink($asset->resolvedPath());
         $signatureFactory = new Signature(config('app.key'));
 
         $params = [

--- a/tests/Controllers/ImageControllerTest.php
+++ b/tests/Controllers/ImageControllerTest.php
@@ -224,7 +224,7 @@ class ImageControllerTest extends TestCase
         $signature = $signatureFactory->generateSignature($asset->url(), $params);
         $params['s'] = $signature;
 
-        $this->expectException(NotFoundHttpException::class);
+        // $this->expectException(NotFoundHttpException::class);
 
         $response = $this->controller->getImageByPreset(
             request(),

--- a/tests/Controllers/ImageControllerTest.php
+++ b/tests/Controllers/ImageControllerTest.php
@@ -233,7 +233,7 @@ class ImageControllerTest extends TestCase
             $signature,
             ltrim($asset->url(), '/'),
             '.webp'
-        );
+        )->throw();
     }
 
     #[Test]

--- a/tests/Controllers/ImageControllerTest.php
+++ b/tests/Controllers/ImageControllerTest.php
@@ -211,7 +211,7 @@ class ImageControllerTest extends TestCase
     public function it_returns_404_when_asset_exists_but_file_is_missing(): void
     {
         $asset = $this->uploadTestAsset('upload_404.png');
-        @unlink($this->assetPath($filename));
+        @unlink($this->assetPath('upload_404.png'));
         $signatureFactory = new Signature(config('app.key'));
 
         $params = [

--- a/tests/Controllers/ImageControllerTest.php
+++ b/tests/Controllers/ImageControllerTest.php
@@ -208,6 +208,35 @@ class ImageControllerTest extends TestCase
     }
 
     #[Test]
+    public function it_returns_404_when_asset_exists_but_file_is_missing(): void
+    {
+        $asset = $this->uploadTestAsset('upload_404.png');
+        @unlink($this->assetPath($filename));
+        $signatureFactory = new Signature(config('app.key'));
+
+        $params = [
+            's' => '',
+            'width' => 350,
+            'height' => 500,
+            'format' => '.webp',
+        ];
+
+        $signature = $signatureFactory->generateSignature($asset->url(), $params);
+        $params['s'] = $signature;
+
+        $this->expectException(NotFoundHttpException::class);
+
+        $response = $this->controller->getImageByPreset(
+            request(),
+            350,
+            500,
+            $signature,
+            ltrim($asset->url(), '/'),
+            '.webp'
+        );
+    }
+
+    #[Test]
     public function it_returns_generated_images_when_they_are_built(): void
     {
         $asset = $this->uploadTestAsset('upload.png');

--- a/tests/Controllers/ImageControllerTest.php
+++ b/tests/Controllers/ImageControllerTest.php
@@ -224,7 +224,7 @@ class ImageControllerTest extends TestCase
         $signature = $signatureFactory->generateSignature($asset->url(), $params);
         $params['s'] = $signature;
 
-        // $this->expectException(NotFoundHttpException::class);
+        $this->expectException(NotFoundHttpException::class);
 
         $response = $this->controller->getImageByPreset(
             request(),
@@ -233,7 +233,7 @@ class ImageControllerTest extends TestCase
             $signature,
             ltrim($asset->url(), '/'),
             '.webp'
-        )->throw();
+        );
     }
 
     #[Test]


### PR DESCRIPTION
On environments where the database has been updated but the files have not errors like these could occur

> Could not find the image `assets/xxxxx.jpg`. {"exception":"[object] (League\\Glide\\Filesystem\\FileNotFoundException(code: 0): Could not find the image `assets/xxxxx.jpg`

This makes sense as the asset exists, but the file it references does not.
This change catches the exception and return like no asset was found. So we get a 404 instead.